### PR TITLE
New: Ensure code coverage is met

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+coverage
 
 # Dependency directories (remove the comment below to include it)
 vendor/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 SHELL := /bin/bash
 OUTPUT_FORMAT = $(shell if [ "${GITHUB_ACTIONS}" == "true" ]; then echo "github"; else echo ""; fi)
+TEST_COVERAGE_PERCENTAGE=70
+COVERAGE_THRESHOLD_FILE=coveragethreshold.json
 
-.PHONY: help
+
+.PHONY: help coverage
 help: ## Shows all targets and help from the Makefile (this message).
 	@echo "slsa-github-generator Makefile"
 	@echo "Usage: make [COMMAND]"
@@ -30,6 +33,13 @@ unit-test: ## Runs all unit tests.
 	go mod vendor
 	go test -mod=vendor -v ./...
 
+coverage: unit-test  ## Runs all unit tests and generates a coverage report.
+	@echo "Ensuring the code coverage is met"
+	@go test -mod=vendor  -coverprofile=coverage ./... | THRESHOLD_FILE=$(COVERAGE_THRESHOLD_FILE) COVERAGE_PERCENTAGE=$(TEST_COVERAGE_PERCENTAGE) go run ./hack/codecoverage/main.go
+
+	@cd .github/actions/detect-workflow
+	@go mod vendor
+	@go test -mod=vendor -coverprofile=coverage ./... | THRESHOLD_FILE=$(COVERAGE_THRESHOLD_FILE)                  COVERAGE_PERCENTAGE=$(TEST_COVERAGE_PERCENTAGE) go run ./hack/codecoverage/main.go 
 
 ## Linters
 #####################################################################

--- a/coveragethreshold.json
+++ b/coveragethreshold.json
@@ -1,0 +1,9 @@
+{
+"github.com/slsa-framework/slsa-github-generator/github":70.4,
+"github.com/slsa-framework/slsa-github-generator/internal/builders/generic": 52.3,
+"github.com/slsa-framework/slsa-github-generator/internal/builders/go":17.1,
+"github.com/slsa-framework/slsa-github-generator/internal/errors":100.0,
+"github.com/slsa-framework/slsa-github-generator/internal/utils":72.1,
+"github.com/slsa-framework/slsa-github-generator/signing/envelope":82.4,
+"github.com/slsa-framework/slsa-github-generator/slsa":54.6
+}

--- a/hack/codecoverage/README.md
+++ b/hack/codecoverage/README.md
@@ -1,0 +1,35 @@
+# Go Coverage tool
+
+The goal of the coverage tool is to measure the coverage of the code base for Golang.
+
+## Usage
+Execute the following command to get the coverage and store it in a file:
+1. `go test  -coverprofile=coverage ./... | THRESHOLD_FILE=./coverage.json COVERAGE_PERCENTAGE=70 go run ./hack/codecoverage/main.go`
+2. The `THRESHOLD_FILE` is the path to the file containing the coverage threshold.
+3. The THRESHOLD_FILE contains the percentage of the code coverage that is required to pass for certain packages. This is usually because they don't match the desired coverage.
+```json
+{
+  "github.com/slsa-framework/slsa-github-generator/github":70.4,
+  "github.com/slsa-framework/slsa-github-generator/internal/builders/generic": 52.3,
+  "github.com/slsa-framework/slsa-github-generator/internal/builders/go":17.1,
+  "github.com/slsa-framework/slsa-github-generator/internal/errors":100.0,
+  "github.com/slsa-framework/slsa-github-generator/internal/utils":72.1,
+  "github.com/slsa-framework/slsa-github-generator/signing/envelope":82.4,
+  "github.com/slsa-framework/slsa-github-generator/slsa":54.6
+}
+```
+3. The `COVERAGE_PERCENTAGE` is the percentage of the code coverage that is required to pass for all the packages except the ones that are mentioned in the `THRESHOLD_FILE`.
+4. The coverage tool will fail if the coverage is below the threshold for any package.
+``` shell
+2022/07/29 16:14:41 github.com/slsa-framework/slsa-github-generator/pkg/foo is below the threshold of 71.000000
+exit status 1
+```
+
+### Design choices
+
+1. The coverage tool should not depend on any other tools. It should work of the results from the `go test` command.
+2. Coverage threshold should be configurable for each repository - for example `70%` within the repository.
+3. A setting file should override the coverage threshold for a given package within the repository. `github.com/foo/bar/xyz : 61`
+4. The coverage tool should use native `go` tools and shouldn't depend on external vendors.
+5. The coverage tool should be configurable as part of the PR to fail if the desired threshold is not met.
+6. Contributors should be able to run it locally if desired before doing a PR.

--- a/hack/codecoverage/go.mod
+++ b/hack/codecoverage/go.mod
@@ -1,0 +1,3 @@
+module github.com/slsa-framework/slsa-github-generator/hack/coverage
+
+go 1.18

--- a/hack/codecoverage/main.go
+++ b/hack/codecoverage/main.go
@@ -1,0 +1,87 @@
+// Copyright 2022 SLSA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func main() {
+	thresholdFile := os.Getenv("THRESHOLD_FILE")
+	if thresholdFile == "" {
+		log.Fatalf("THRESHOLD_FILE environment variable is not set")
+	}
+	thresholdMap, err := parseCoverageThreshold(thresholdFile)
+	if err != nil {
+		log.Fatalf("Error parsing threshold file: %v", err)
+	}
+	coveragePercentage := os.Getenv("COVERAGE_PERCENTAGE")
+	if coveragePercentage == "" {
+		log.Fatalf("COVERAGE_PERCENTAGE environment variable is not set")
+	}
+	coveragePercentageFloat, err := strconv.ParseFloat(coveragePercentage, 32)
+	if err != nil {
+		log.Fatalf("Error parsing coverage percentage: %v", err)
+	}
+	// read stream from stdin
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, "coverage: ") {
+			parts := strings.Fields(line)
+			if len(parts) < 5 {
+				continue
+			}
+			percentage, err := strconv.ParseFloat(strings.Trim(parts[4], "%"), 32)
+			if err != nil {
+				log.Fatalf("invalid line: %s", line)
+			}
+			pack := parts[1]
+			if val, ok := thresholdMap[pack]; !ok {
+				if float32(int(percentage*100)/100) < float32(int(coveragePercentageFloat*100)/100) {
+					log.Fatalf("coverage for %s is below threshold: %f < %f", pack, percentage, coveragePercentageFloat)
+				}
+			} else {
+				if float32(int(percentage*100)/100) < float32(int(val*100)/100) {
+					log.Fatalf("coverage for %s is below threshold: %f < %f", pack, percentage, val)
+				}
+			}
+		}
+	}
+}
+
+// parseCoverageThreshold parses the threshold file and returns a map.
+func parseCoverageThreshold(fileName string) (map[string]float64, error) {
+	// Here is an example of the threshold file:
+	/*
+		{
+			  "github.com/foo/bar/pkg/cryptoutils": 71.2,
+			}
+	*/
+	f, err := os.Open(fileName)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	thresholdMap := make(map[string]float64)
+	if err := json.NewDecoder(f).Decode(&thresholdMap); err != nil {
+		return nil, err
+	}
+	return thresholdMap, nil
+}


### PR DESCRIPTION
- This will enable the desired code coverage is met for the project
- The coverage is set to 70 to start off with. This setting is in the
  Makefile
- The coveragethreshold.json is an override for packages which have
  different coverage needs from the global coverage threshold.
- The code coverage tool uses standard go tool.

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>